### PR TITLE
feat: rotate logs per start

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight process manager inspired by PM2, but designed primarily for develo
 - `start`, `stop`, and `restart` services, similar to PM2
 - Simple YAML configuration
 - Real-time logs with highlight
+- Automatic log rotation per run (keeps up to 30 log files)
 - Environment variable support
 - Automatic `.env` file loading
 - Multi-machine support with hostname-specific directories (for shared NAS environments)


### PR DESCRIPTION
## Summary
- rotate service logs on each start using logrotate-style naming
- support rotating and cleaning log files in flush command
- document automatic log rotation in features list

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68b5b7f2608083299795d4672d14c93d