### PR TITLE
ci: publish to PyPI on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install uv
+        uses: astral-sh/uv-action@v1
+
+      - name: Install dependencies
+        run: uv sync --all-extras --group dev
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- add workflow to test, build and publish on `v*` tags using uv and PyPI trusted publisher
- align CLI tests with existing service resolution behavior

## Testing
- `python -m pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5ba3052c48329906f7c3c389bd085