### PR TITLE
refactor: improve PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,16 +10,18 @@ permissions:
   id-token: write
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install uv
         uses: astral-sh/uv-action@v1
@@ -35,3 +37,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true


### PR DESCRIPTION
## Summary
- refine PyPI publishing workflow
- ensure full history for tag-based builds and handle repeated publishes

## Testing
- `uv run pytest`
- `uv build`


------
https://chatgpt.com/codex/tasks/task_e_68b64887fcd08329a1a60f3dfb50408b